### PR TITLE
Added Unlock Key for GuiCreateWorld

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ modId = defaultworldgenerator
 modGroup = com.fireball1725.defaultworldgenerator
 
 # Whether to use modGroup as the maven publishing group.
-# Due to a history of using JitPack, the default is com.github.GTNewHorizons for all mods.
+# When false, com.github.GTNewHorizons is used.
 useModGroupForPublishing = false
 
 # Updates your build.gradle and settings.gradle automatically whenever an update is available.
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -61,6 +61,9 @@ gradleTokenModId = GRADLETOKEN_MODID
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName = GRADLETOKEN_MODNAME
 
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName = GRADLETOKEN_GROUPNAME
+
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
 # public static final String VERSION = "GRADLETOKEN_VERSION";
@@ -81,6 +84,11 @@ accessTransformersFile =
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = false
+
+# Set to a non-empty string to configure mixins in a separate source set under src/VALUE, instead of src/main.
+# This can speed up compile times thanks to not running the mixin annotation processor on all input sources.
+# Mixin classes will have access to "main" classes, but not the other way around.
+separateMixinSourceSet =
 
 # Adds some debug arguments like verbose output and class export.
 usesMixinDebug = false
@@ -114,8 +122,14 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
+
+# A list of repositories to exclude from the includeWellKnownRepositories setting. Should be a space separated
+# list of strings, with the acceptable keys being(case does not matter):
+# cursemaven
+# modrinth
+excludeWellKnownRepositories =
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
 # Authenticate with the MAVEN_USER and MAVEN_PASSWORD environment variables.
@@ -123,7 +137,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +201,3 @@ curseForgeRelations =
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = GRADLETOKEN_GROUPNAME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.38'
 }
 
 

--- a/src/main/java/com/fireball1725/defaultworldgenerator/events/GuiEvents.java
+++ b/src/main/java/com/fireball1725/defaultworldgenerator/events/GuiEvents.java
@@ -5,6 +5,8 @@ import net.minecraft.client.gui.GuiCreateWorld;
 import net.minecraft.client.gui.GuiSelectWorld;
 import net.minecraftforge.client.event.GuiScreenEvent;
 
+import org.lwjgl.input.Keyboard;
+
 import com.fireball1725.defaultworldgenerator.config.ConfigGeneralSettings;
 import com.fireball1725.defaultworldgenerator.gui.GuiCreateCustomWorld;
 
@@ -26,7 +28,7 @@ public class GuiEvents {
 
         if (event.gui instanceof GuiCreateWorld) {
             if (event.button.id == 5) {
-                if (ConfigGeneralSettings.generalLockWorldGenerator) {
+                if (ConfigGeneralSettings.generalLockWorldGenerator && !Keyboard.isKeyDown(Keyboard.KEY_LMENU)) {
                     event.button.func_146113_a(Minecraft.getMinecraft().getSoundHandler());
                     event.setCanceled(true);
                 }


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19853

With this PR, you can now unlock the default level type by pressing the <kbd>Left Alt</kbd>.
This is inspired by modern Minecraft, where you need to "unlock" the debug level type by pressing alts.

This PR gives convenience to people who will create their test worlds in something like super flat while not removing this world.
